### PR TITLE
#89: Adding a catch in the decoder for unset trace lengths.

### DIFF
--- a/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
@@ -144,8 +144,13 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(unsigned int *buf, const 
         data->SetFilterTime(times.first);
         data->SetTime(times.second);
 
-        // One last check to ensure event length matches what we think it
-        // should be.
+        // Some events get a trace length of 32768, this shows up here as 32767. If we encounter a trace length of that
+        // size then we're going to set the trace length to 0. There's never a situation where a trace can have that
+        // many samples. For a 250 Ms/s module that corresponds to a trace length of 131 us.
+        if(traceLength == 32767)
+            traceLength = 0;
+
+        // One last check to ensure event length matches what we think it should be.
         if (traceLength / 2 + headerLength != eventLength) {
             numSkippedBuffers++;
             cerr << "XiaListModeDataDecoder::ReadBuffer : Event"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fixes issue decoding data with trace lengths set to 32767
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#89 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Scanned data where this occurred without any issue.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [Contributing](https://github.com/spaulaus/paass/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
